### PR TITLE
feat: add code-server and SSH agent forwarding for remote dev

### DIFF
--- a/dot_ssh/.chezmoiattrs
+++ b/dot_ssh/.chezmoiattrs
@@ -1,0 +1,1 @@
+* private

--- a/dot_ssh/config.tmpl
+++ b/dot_ssh/config.tmpl
@@ -1,0 +1,19 @@
+{{- if eq .chezmoi.os "darwin" }}
+Include ~/.ssh/1Password/config
+
+Host *
+	IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+
+{{- end }}
+
+Host *
+	CanonicalizeHostname yes
+	CanonicalDomains halosaur-major.ts.net
+	CanonicalizeMaxDots 0
+
+Host *.halosaur-major.ts.net
+	ForwardAgent yes
+
+Host echo-dev.local
+	HostName echo-dev.local
+	User admin

--- a/run_install-packages.sh.tmpl
+++ b/run_install-packages.sh.tmpl
@@ -51,6 +51,9 @@ if [[ "$os" == "darwin" ]]; then
   [[ -r "$HOME/.fzf.zsh" ]] || "$(brew --prefix)/opt/fzf/install" --key-bindings --completion --no-update-rc || true
   install_cargo_packages
   install_uv_tools
+{{ if .full_setup }}
+  brew install code-server 2>/dev/null || true
+{{ end }}
   exit 0
 fi
 
@@ -285,6 +288,13 @@ install_bandwhich_user() {
   export PATH="$HOME/.local/bin:$PATH"
 }
 
+install_code_server_user() {
+  command -v code-server >/dev/null 2>&1 && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone || true
+  export PATH="$HOME/.local/lib/code-server-*/bin:$PATH"
+}
+
 install_procs_user() {
   command -v procs >/dev/null 2>&1 && return 0
   command -v curl >/dev/null 2>&1 || return 0
@@ -393,6 +403,8 @@ fi
 install_duf_user
 install_bandwhich_user
 install_procs_user
+install_code_server_user
+systemctl --user enable --now code-server 2>/dev/null || true
 {{ end -}}
 
 # ---- Post-package-manager installs (GitHub releases / official installers) ----


### PR DESCRIPTION
## Summary
- Install code-server on macOS (Homebrew) and Linux (standalone installer) for VS Code Remote access, gated behind `full_setup`
- On Linux, enables the systemd user service automatically
- Add chezmoi-managed `~/.ssh/config` with 1Password agent forwarding to all tailnet hosts
- Uses `CanonicalizeHostname` so short tailnet names (`ssh echo-turbine`) also forward the agent

## TODO
- [ ] Test whether Tailscale's MagicDNS search domains make the `CanonicalizeHostname` config redundant
- [ ] Verify code-server standalone install + systemd enable on a fresh Linux box
- [ ] Confirm git commit signing works over the forwarded agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)