### PR TITLE
feat(ssh): add fog-jump-* host config

### DIFF
--- a/dot_config/ssh/config
+++ b/dot_config/ssh/config
@@ -1,6 +1,11 @@
 # Allow 1Password to manage its own SSH config
 Include ~/.ssh/1Password/config
 
+Host fog-jump-*
+  User admin
+  IdentitiesOnly yes
+  SetEnv TERM=xterm-256color
+
 Host *
   IdentityAgent $SSH_AUTH_SOCK
   AddKeysToAgent no


### PR DESCRIPTION
## Summary

- Adds an SSH config block for `fog-jump-*` hosts with `User admin`, `IdentitiesOnly yes`, and `SetEnv TERM=xterm-256color`.

## Test plan

- [ ] `chezmoi apply` updates `~/.ssh/config` cleanly
- [ ] `ssh -G fog-jump-example` reports `user admin` and `identitiesonly yes`
- [ ] Connecting to a real fog-jump host preserves a 256-color TERM