### PR TITLE
feat(shell): add ntfy for long-command notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Base permissions are merged into `settings.json` by the modify script (existing 
 
 - **Repo lookup**: Run `find-repo <name>` to resolve a repo name to its filesystem path. Uses ghq. Supports partial matching (e.g., `find-repo pricing` matches `pricing-portal`). Run with no args to list all repos.
 - **Remote SSH signing**: `~/.config/git/ssh-sign` wraps `ssh-keygen` as `gpg.ssh.program`. In local sessions it passes through to 1Password; in remote sessions (`SSH_CONNECTION` set or no 1Password socket) it falls back to `~/.ssh/id_ed25519_remote`. The fallback key is generated once by `run_once_11-remote-signing-key.sh.tmpl`.
+- **ntfy notifications**: `ntfy` (installed via `uv tool install`) auto-notifies when commands taking >10s finish in an unfocused terminal. Backend config lives in `~/.ntfy.yml` (one-time manual setup; e.g., Pushover with `user_key`). Use `ntfy done <cmd>` to force-track. `AUTO_NTFY_DONE_IGNORE` in `env.zsh` silences interactive tools (vim, tmux, ssh, claude, etc.).
 
 ### Shell Functions (pipe mode)
 

--- a/dot_config/shell/env.zsh
+++ b/dot_config/shell/env.zsh
@@ -243,6 +243,13 @@ fi
 # Rust
 [[ -r "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
 
+# ntfy: auto-notify when long-running commands finish in an unfocused terminal.
+# Reads ~/.ntfy.yml (Pushover or other backends). Skip with AUTO_NTFY_DONE_IGNORE.
+if command -v ntfy >/dev/null 2>&1; then
+  export AUTO_NTFY_DONE_IGNORE="${AUTO_NTFY_DONE_IGNORE:-vim nvim micro less more man tmux screen ssh mosh htop btop ncdu yazi watch fzf claude}"
+  eval "$(ntfy shell-integration 2>/dev/null)" 2>/dev/null || true
+fi
+
 # Homebrew OpenSSL hint (only if brew exists)
 if command -v brew >/dev/null 2>&1; then
   _brew_prefix="${_brew_prefix:-$(brew --prefix)}"

--- a/run_install-packages.sh.tmpl
+++ b/run_install-packages.sh.tmpl
@@ -2,7 +2,7 @@
 set -euo pipefail
 # Brewfile hash: {{ include "Brewfile" | sha256sum }}
 # cargo-packages: markless
-# uv-tools: specify-cli
+# uv-tools: specify-cli ntfy
 # linux-pkg-v5
 
 os="{{ .chezmoi.os }}"
@@ -20,10 +20,11 @@ install_cargo_packages() {
 install_uv_tools() {
   command -v uv >/dev/null 2>&1 || return 0
   command -v specify >/dev/null 2>&1 || uv tool install specify-cli || true
+  command -v ntfy >/dev/null 2>&1 || uv tool install 'ntfy[pid,emoji]' || true
 }
 
 want_cmds=(git fzf bat zoxide)
-want_cmds_optional=(rg gh starship eza delta ghq glow navi tldr micro mosh specify)
+want_cmds_optional=(rg gh starship eza delta ghq glow navi tldr micro mosh specify ntfy)
 
 missing=0
 for c in "${want_cmds[@]}" "${want_cmds_optional[@]}"; do


### PR DESCRIPTION
## Summary

- Installs [`dschep/ntfy`](https://github.com/dschep/ntfy) via `uv tool install 'ntfy[pid,emoji]'` in `run_install-packages.sh.tmpl` (works on macOS and Linux).
- Wires `ntfy shell-integration` into `dot_config/shell/env.zsh`, guarded by `command -v ntfy`.
- Sets a sensible `AUTO_NTFY_DONE_IGNORE` default (vim, tmux, ssh, claude, etc.) so interactive sessions don't fire notifications.
- Documents the integration in `CLAUDE.md`.

## Follow-up (manual, one-time per machine)

Create `~/.ntfy.yml` with the desired backend. For Pushover:

```yaml
backends:
    - pushover
pushover:
    user_key: <your-pushover-user-key>
```

Not templated from 1Password yet — can add `private_dot_ntfy.yml.tmpl` in a follow-up once a vault item path is decided.

## Test plan

- [ ] `chezmoi apply` runs cleanly
- [ ] `command -v ntfy` resolves after apply (uv tool installed)
- [ ] New zsh sessions have `precmd_functions` containing `auto_ntfy_done` (verify: `print -l $precmd_functions`)
- [ ] `sleep 12` in an unfocused terminal (after creating `~/.ntfy.yml`) fires a Pushover notification
- [ ] `vim` (in `AUTO_NTFY_DONE_IGNORE`) does not fire a notification when exiting after >10s