### PR TITLE
chore(pr-skill): drop Copilot reviewer step

### DIFF
--- a/dot_claude/skills/pr/SKILL.md
+++ b/dot_claude/skills/pr/SKILL.md
@@ -50,20 +50,10 @@ Use `gh pr create` with:
 <Bulleted checklist of how to verify the changes>
 ```
 
-### 5. Request Review
-
-Assign `@Copilot` as a reviewer:
-
-```bash
-gh pr edit --add-reviewer Copilot
-```
-
-This is fire-and-forget — if it fails (e.g., Copilot not available in the repo), log the error but don't block.
-
-### 6. Link
+### 5. Link
 
 If the org is `unstable-studios` and `link-unstable` is available, run it.
 
-### 7. Done
+### 6. Done
 
 Print the PR URL.


### PR DESCRIPTION
## Summary

- Removes the `### 5. Request Review` step from `dot_claude/skills/pr/SKILL.md` that ran `gh pr edit --add-reviewer Copilot`. It always failed on repos without Copilot reviewers enabled (including this one), adding noise without value.
- Renumbers the remaining steps: Link is now 5, Done is now 6.

Pulls a tweak that was already made directly in `~/.claude/skills/pr/SKILL.md` back into the source.

## Test plan

- [ ] `chezmoi diff dot_claude/skills/pr/SKILL.md` is clean after merging + applying
- [ ] Running `/pr` no longer attempts the Copilot reviewer step