### PR TITLE
feat(ntfy): template ~/.ntfy.yml from 1Password

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -42,3 +42,8 @@ Library/Application Support/Code/**
 .config/iterm2/
 .config/iterm2/**
 {{- end -}}
+
+{{- if not .full_setup }}
+# ntfy config requires 1Password
+.ntfy.yml
+{{- end -}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/private_*
+!**/private_*.tmpl
 **/.DS_Store
 **/.zcompdump*
 **/.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Base permissions are merged into `settings.json` by the modify script (existing 
 
 - **Repo lookup**: Run `find-repo <name>` to resolve a repo name to its filesystem path. Uses ghq. Supports partial matching (e.g., `find-repo pricing` matches `pricing-portal`). Run with no args to list all repos.
 - **Remote SSH signing**: `~/.config/git/ssh-sign` wraps `ssh-keygen` as `gpg.ssh.program`. In local sessions it passes through to 1Password; in remote sessions (`SSH_CONNECTION` set or no 1Password socket) it falls back to `~/.ssh/id_ed25519_remote`. The fallback key is generated once by `run_once_11-remote-signing-key.sh.tmpl`.
-- **ntfy notifications**: `ntfy` (installed via `uv tool install`) auto-notifies when commands taking >10s finish in an unfocused terminal. Backend config lives in `~/.ntfy.yml` (one-time manual setup; e.g., Pushover with `user_key`). Use `ntfy done <cmd>` to force-track. `AUTO_NTFY_DONE_IGNORE` in `env.zsh` silences interactive tools (vim, tmux, ssh, claude, etc.).
+- **ntfy notifications**: `ntfy` (installed via `uv tool install`) auto-notifies when commands taking >10s finish in an unfocused terminal. On `full_setup` machines, `~/.ntfy.yml` is rendered from `private_dot_ntfy.yml.tmpl` with Pushover credentials pulled from 1Password at apply time; otherwise the file is skipped via `.chezmoiignore`. Use `ntfy done <cmd>` to force-track. `AUTO_NTFY_DONE_IGNORE` in `env.zsh` silences interactive tools (vim, tmux, ssh, claude, etc.).
 
 ### Shell Functions (pipe mode)
 

--- a/private_dot_ntfy.yml.tmpl
+++ b/private_dot_ntfy.yml.tmpl
@@ -1,0 +1,11 @@
+{{- /*
+ntfy (dschep/ntfy) Pushover backend config.
+Tokens pulled from 1Password at `chezmoi apply` time; written to ~/.ntfy.yml (0600).
+In 1Password: `username` field holds the Pushover user key, `credential` holds the app API token.
+*/ -}}
+---
+backends:
+  - pushover
+pushover:
+  user_key: {{ onepasswordRead "op://Private/aoupzcglochihuupjzm2rm2e74/username" "PRVINDHU6FCCRFRCUD3NNHCJ7M" | quote }}
+  api_token: {{ onepasswordRead "op://Private/aoupzcglochihuupjzm2rm2e74/credential" "PRVINDHU6FCCRFRCUD3NNHCJ7M" | quote }}


### PR DESCRIPTION
## Summary
- Adds `private_dot_ntfy.yml.tmpl` — chezmoi renders `~/.ntfy.yml` at apply time, pulling Pushover `user_key` + `api_token` from 1Password (personal account).
- Gated behind `full_setup` via `.chezmoiignore.tmpl` so Codespaces / minimal installs skip it (ntfy binary still installs; no config just means no auto-notify, as before #14 landed).
- Narrows repo `.gitignore`: `private_*` stays ignored, but `private_*.tmpl` sources are now tracked — the template only holds `op://` references, not secrets.
- Updates CLAUDE.md ntfy note to reflect the new flow.

## Test plan
- [x] `chezmoi execute-template` renders the template with resolved tokens
- [ ] `chezmoi apply` writes `~/.ntfy.yml` at mode `0600`
- [ ] Run a long (>10s) command in an unfocused terminal — Pushover notification arrives
- [ ] Fresh machine w/ `full_setup=false` — no `~/.ntfy.yml` created, `chezmoi apply` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)