### PR TITLE
feat(ntfy): per-host title prompt + longer_than: 30

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -29,10 +29,22 @@
 {{-   $fullSetup = promptBool "Full setup? (1Password, secrets) (y/N, default: No)" -}}
 {{- end }}
 
+{{- /* Ntfy title: only prompted on full_setup machines. Defaults to hostname. */ -}}
+{{- $ntfyTitle := $hostname -}}
+{{- if hasKey . "ntfy_title" -}}
+{{-   $ntfyTitle = .ntfy_title -}}
+{{- else if $fullSetup -}}
+{{-   $ntfyTitle = promptString (printf "ntfy notification title (%s)" $hostname) -}}
+{{-   if eq $ntfyTitle "" -}}
+{{-     $ntfyTitle = $hostname -}}
+{{-   end -}}
+{{- end }}
+
 [data]
   hostname = {{ $hostname | quote }}
   is_server = {{ $isServer }}
   full_setup = {{ $fullSetup }}
+  ntfy_title = {{ $ntfyTitle | quote }}
 
 {{- if lookPath "delta" }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Base permissions are merged into `settings.json` by the modify script (existing 
 
 - **Repo lookup**: Run `find-repo <name>` to resolve a repo name to its filesystem path. Uses ghq. Supports partial matching (e.g., `find-repo pricing` matches `pricing-portal`). Run with no args to list all repos.
 - **Remote SSH signing**: `~/.config/git/ssh-sign` wraps `ssh-keygen` as `gpg.ssh.program`. In local sessions it passes through to 1Password; in remote sessions (`SSH_CONNECTION` set or no 1Password socket) it falls back to `~/.ssh/id_ed25519_remote`. The fallback key is generated once by `run_once_11-remote-signing-key.sh.tmpl`.
-- **ntfy notifications**: `ntfy` (installed via `uv tool install`) auto-notifies when commands taking >10s finish in an unfocused terminal. On `full_setup` machines, `~/.ntfy.yml` is rendered from `private_dot_ntfy.yml.tmpl` with Pushover credentials pulled from 1Password at apply time; otherwise the file is skipped via `.chezmoiignore`. Use `ntfy done <cmd>` to force-track. `AUTO_NTFY_DONE_IGNORE` in `env.zsh` silences interactive tools (vim, tmux, ssh, claude, etc.).
+- **ntfy notifications**: `ntfy` (installed via `uv tool install`) auto-notifies when commands taking >30s (`longer_than`) finish in an unfocused terminal. On `full_setup` machines, `~/.ntfy.yml` is rendered from `private_dot_ntfy.yml.tmpl` with Pushover credentials pulled from 1Password at apply time; notification title comes from `ntfy_title` (prompted once at `chezmoi init`, defaults to hostname). Use `ntfy done <cmd>` to force-track. `AUTO_NTFY_DONE_IGNORE` in `env.zsh` silences interactive tools (vim, tmux, ssh, claude, etc.).
 
 ### Shell Functions (pipe mode)
 

--- a/private_dot_ntfy.yml.tmpl
+++ b/private_dot_ntfy.yml.tmpl
@@ -2,8 +2,14 @@
 ntfy (dschep/ntfy) Pushover backend config.
 Tokens pulled from 1Password at `chezmoi apply` time; written to ~/.ntfy.yml (0600).
 In 1Password: `username` field holds the Pushover user key, `credential` holds the app API token.
+`ntfy_title` comes from chezmoi data (set by .chezmoi.toml.tmpl on init); falls back to
+hostname if missing so `chezmoi apply` still works before re-running `chezmoi init`.
 */ -}}
+{{- $title := .chezmoi.hostname -}}
+{{- if hasKey . "ntfy_title" -}}{{- $title = .ntfy_title -}}{{- end }}
 ---
+title: {{ $title | quote }}
+longer_than: 30
 backends:
   - pushover
 pushover:


### PR DESCRIPTION
## Summary
- `.chezmoi.toml.tmpl` now prompts for `ntfy_title` on `full_setup` machines (defaults to hostname). Only fires on first init or when the key is missing — existing `chezmoi.toml` data is preserved.
- `private_dot_ntfy.yml.tmpl` renders `title:` from `.ntfy_title` and sets `longer_than: 30` so sub-30s commands stop buzzing Pushover.
- Template falls back to `.chezmoi.hostname` if `ntfy_title` isn't in data yet, so `chezmoi apply` still works before you re-run `chezmoi init` on existing machines.

## Test plan
- [x] `chezmoi execute-template` renders with fallback title (current machine hasn't re-inited yet)
- [ ] `chezmoi init` on this machine → prompts for ntfy_title only (leaves hostname/is_server/full_setup alone)
- [ ] After `chezmoi apply`, `~/.ntfy.yml` shows the chosen title and `longer_than: 30`
- [ ] A 10s command in an unfocused terminal → no notification; a 45s command → notification with the chosen title

🤖 Generated with [Claude Code](https://claude.com/claude-code)