### PR TITLE
fix(windows-terminal): match installed font family name

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,13 @@ Two notes:
 
 - **Launch Windows Terminal once first** so `settings.json` and the WSL profile exist; the
   script runs on every `chezmoi apply` and is a no-op until then (and idempotent after).
-- **Install `JetBrainsMono Nerd Font` on Windows** for starship/eza glyphs (Ghostty has a
-  built-in Nerd Font fallback; Windows Terminal does not). Grab it from
-  [nerdfonts.com](https://www.nerdfonts.com/font-downloads), or with `scoop`:
-  `scoop bucket add nerd-fonts && scoop install JetBrains-Mono`.
+- **Install a JetBrains Mono Nerd Font on Windows** for starship/eza glyphs (Ghostty has a
+  built-in Nerd Font fallback; Windows Terminal does not). With `scoop` (run from Windows
+  PowerShell, not WSL): `scoop bucket add nerd-fonts && scoop install JetBrains-Mono`, or
+  grab it from [nerdfonts.com](https://www.nerdfonts.com/font-downloads). Then check the
+  exact family name in the Windows Terminal font dropdown — it may register as
+  `JetBrains Mono` or `JetBrainsMono Nerd Font` depending on the build — and make
+  `FONT_FACE` in `run_windows-terminal.sh.tmpl` match it.
 
 ---
 

--- a/run_windows-terminal.sh.tmpl
+++ b/run_windows-terminal.sh.tmpl
@@ -48,9 +48,12 @@ SCHEME = {
     "brightYellow": "#efd64b", "brightBlue": "#387cd3", "brightPurple": "#957bbe",
     "brightCyan": "#3d97e2", "brightWhite": "#bababa",
 }
-# Use the Nerd Font variant so starship/eza glyphs render (install it on Windows;
-# see the README). Falls back gracefully if absent.
-FONT_FACE = "JetBrainsMono Nerd Font"
+# Must match the family name Windows registered for the installed font (check the
+# Windows Terminal font dropdown). The scoop nerd-fonts JetBrains-Mono registers
+# under the base "JetBrains Mono" name here, and its glyphs (starship/eza) come
+# from that patched file. If icons render as boxes, set this to the exact Nerd
+# Font family name shown in the dropdown instead.
+FONT_FACE = "JetBrains Mono"
 FONT_SIZE = 14
 
 def strip_jsonc(text):


### PR DESCRIPTION
## Summary

- WT reported a missing font because the face string `JetBrainsMono Nerd Font` didn't match what Windows actually registered — the scoop nerd-fonts JetBrains-Mono shows as **`JetBrains Mono`** in the font dropdown on this machine.
- Sets `FONT_FACE = "JetBrains Mono"`; glyphs come from the patched file under that name. Comment + README note the name can vary by build and must match the dropdown.

## Test plan

- [x] Merge re-tested: `font.face` now `JetBrains Mono`, rest of merge unchanged.
- [ ] Real WSL box: `chezmoi apply`, restart Windows Terminal → no missing-font warning; starship/eza icons render (if boxes, swap to the exact Nerd Font dropdown name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)