### PR TITLE
fix(windows-terminal): use JetBrainsMono Nerd Font Mono face

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,14 @@ Two notes:
 
 - **Launch Windows Terminal once first** so `settings.json` and the WSL profile exist; the
   script runs on every `chezmoi apply` and is a no-op until then (and idempotent after).
-- **Install a JetBrains Mono Nerd Font on Windows** for starship/eza glyphs (Ghostty has a
+- **Install the JetBrains Mono Nerd Font on Windows** for starship/eza glyphs (Ghostty has a
   built-in Nerd Font fallback; Windows Terminal does not). With `scoop` (run from Windows
-  PowerShell, not WSL): `scoop bucket add nerd-fonts && scoop install JetBrains-Mono`, or
-  grab it from [nerdfonts.com](https://www.nerdfonts.com/font-downloads). Then check the
-  exact family name in the Windows Terminal font dropdown — it may register as
-  `JetBrains Mono` or `JetBrainsMono Nerd Font` depending on the build — and make
-  `FONT_FACE` in `run_windows-terminal.sh.tmpl` match it.
+  PowerShell, not WSL):
+  `scoop bucket add nerd-fonts && scoop install JetBrainsMono-NF-Mono`. Note the package is
+  `JetBrainsMono-NF-Mono` (patched, registers as `JetBrainsMono Nerd Font Mono`) — **not**
+  the plain `JetBrains-Mono`, which ships no glyphs despite living in the same bucket. The
+  `-Mono` variant keeps icons single-cell-width, best for terminals. `FONT_FACE` in
+  `run_windows-terminal.sh.tmpl` must match the family name shown in the WT font dropdown.
 
 ---
 

--- a/run_windows-terminal.sh.tmpl
+++ b/run_windows-terminal.sh.tmpl
@@ -49,11 +49,10 @@ SCHEME = {
     "brightCyan": "#3d97e2", "brightWhite": "#bababa",
 }
 # Must match the family name Windows registered for the installed font (check the
-# Windows Terminal font dropdown). The scoop nerd-fonts JetBrains-Mono registers
-# under the base "JetBrains Mono" name here, and its glyphs (starship/eza) come
-# from that patched file. If icons render as boxes, set this to the exact Nerd
-# Font family name shown in the dropdown instead.
-FONT_FACE = "JetBrains Mono"
+# Windows Terminal font dropdown). Install the patched font on Windows via scoop:
+# `scoop install JetBrainsMono-NF-Mono` (the plain `JetBrains-Mono` package has no
+# glyphs). The "Mono" Nerd Font variant keeps icons single-cell-width for terminals.
+FONT_FACE = "JetBrainsMono Nerd Font Mono"
 FONT_SIZE = 14
 
 def strip_jsonc(text):


### PR DESCRIPTION
## Summary

- Icons rendered as tofu because the installed font was the **plain** JetBrains Mono (faces `JetBrains Mono` / `JetBrains Mono NL`, no glyphs) — the scoop `JetBrains-Mono` package is the un-patched one, confusingly shipped from the `nerd-fonts` bucket.
- Sets `FONT_FACE = "JetBrainsMono Nerd Font Mono"` (the patched `-Mono` variant, confirmed installed/registered on the box).
- README now points at `scoop install JetBrainsMono-NF-Mono` and calls out the plain-vs-patched gotcha.

## Test plan

- [x] Merge re-tested: `font.face` -> `JetBrainsMono Nerd Font Mono`.
- [ ] WSL box: `chezmoi apply`, restart Windows Terminal → starship/eza icons render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)