### PR TITLE
feat(dev-openshift): opt-in OpenShift client toolchain for WSL

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -51,12 +51,24 @@
 {{-   $opMode = .op_mode -}}
 {{- end }}
 
+{{- /* OpenShift client dev toolchain: opt-in. Installs Node/Python/Ansible in WSL and
+       shims Podman/Helm/oc to the Windows .exe. Env var seeds on first init, then persists. */ -}}
+{{- $devOpenshift := false -}}
+{{- if hasKey . "dev_openshift" -}}
+{{-   $devOpenshift = .dev_openshift -}}
+{{- else if env "DOTFILES_OPENSHIFT" -}}
+{{-   $devOpenshift = true -}}
+{{- else -}}
+{{-   $devOpenshift = promptBool "OpenShift dev toolchain? (Node, Python, Ansible, Podman/Helm/oc shims) (y/N, default: No)" -}}
+{{- end }}
+
 [data]
   hostname = {{ $hostname | quote }}
   is_server = {{ $isServer }}
   full_setup = {{ $fullSetup }}
   ntfy_title = {{ $ntfyTitle | quote }}
   op_mode = {{ $opMode | quote }}
+  dev_openshift = {{ $devOpenshift }}
 
 {{- if lookPath "delta" }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ VS Code templates live in `.chezmoitemplates/vscode/` as the single source of tr
 Chezmoi templates use Go template syntax with these key variables:
 - `.chezmoi.os` - Operating system ("darwin", "linux")
 - `.codespaces` - Boolean for GitHub Codespaces environment
+- `.full_setup` - Boolean; enables 1Password/secrets (seed: `DOTFILES_FULL`)
+- `.op_mode` - `"account"` (desktop app) or `"service"` (token); see Utilities
+- `.dev_openshift` - Boolean; opt-in OpenShift client toolchain (seed: `DOTFILES_OPENSHIFT`). When set, `run_dev-openshift.sh.tmpl` installs Node 22 (fnm)/Python/Ansible in WSL and symlinks `podman`/`helm`/`oc` to the Windows `.exe`; `scripts/windows-client.ps1` handles the Windows side. Read flags with `dig "dev_openshift" false .` (key may be absent pre-init).
 - Secrets accessed via `{{ secret ... }}` with 1Password
 
 ## External Dependencies

--- a/README.md
+++ b/README.md
@@ -136,6 +136,33 @@ Two notes:
   `-Mono` variant keeps icons single-cell-width, best for terminals. `FONT_FACE` in
   `run_windows-terminal.sh.tmpl` must match the family name shown in the WT font dropdown.
 
+#### OpenShift client dev toolchain (`dev_openshift`)
+
+Opt-in toolchain for the OpenShift client engagement. Enable it at init by answering yes to
+the "OpenShift dev toolchain?" prompt, seeding `DOTFILES_OPENSHIFT=1` in the env, or setting
+`dev_openshift = true` in the chezmoi config. It's off by default, so personal machines are
+unaffected.
+
+When on, `run_dev-openshift.sh.tmpl` (every apply, idempotent) installs **inside WSL/Linux**:
+
+- **Node.js 22 LTS** via [`fnm`](https://github.com/Schniz/fnm) (installed to `~/.local/bin`;
+  `env.zsh` wires up `fnm env --use-on-cd`).
+- **Python 3** with `venv`/`pip` (`python3-full` on apt).
+- **Ansible**, isolated via `uv tool install ansible` (falls back to a `~/.venvs/ansible` venv).
+
+And on WSL it **symlinks the Windows binaries** into `~/.local/bin` — `podman`, `helm`, `oc` →
+the `.exe` on the Windows PATH (these are the FIPS-approved Windows builds; chezmoi shims, it
+does not install them). Git stays WSL-native on purpose. If a `.exe` isn't found, apply still
+succeeds and prints a hint.
+
+> Path-translation caveat: the shimmed `podman`/`helm`/`oc` are Windows binaries, so paths you
+> pass them are Windows paths — use `wslpath -w` when handing them a WSL path.
+
+The Windows side is a separate, explicit step — run **`scripts/windows-client.ps1`** once from
+**Windows PowerShell** (the repo is reachable at `\\wsl$\<distro>\home\<you>\.local\share\chezmoi\`).
+It installs Podman, Podman Desktop, Helm, Git for Windows (winget) and `oc` (public mirror).
+**CRC and its FIPS bundle** need a Red Hat pull secret and are printed as manual steps.
+
 ---
 
 ## Updating

--- a/dot_config/shell/env.zsh
+++ b/dot_config/shell/env.zsh
@@ -33,6 +33,11 @@ if command -v ghq >/dev/null 2>&1; then
   mkdir -p "$GHQ_ROOT" 2>/dev/null || true
 fi
 
+# fnm (Node version manager) — only present on dev_openshift boxes
+if command -v fnm >/dev/null 2>&1; then
+  eval "$(fnm env --use-on-cd --shell zsh)"
+fi
+
 
 # ---- 1Password CLI / chezmoi integration ----
 # Headless/WSL boxes authenticate with a service-account token instead of the

--- a/run_dev-openshift.sh.tmpl
+++ b/run_dev-openshift.sh.tmpl
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+{{ if and (eq .chezmoi.os "linux") (dig "dev_openshift" false .) -}}
+
+# OpenShift client dev toolchain (opt-in via the `dev_openshift` flag).
+#   - Installs Node 22 LTS, Python 3 + venv, and Ansible INSIDE WSL/Linux.
+#   - On WSL, symlinks Podman / Helm / oc to the FIPS-approved Windows binaries
+#     (does not install them — see scripts/windows-client.ps1 for the Windows side).
+# Plain run_ (every apply): idempotent, each step guarded so it retries cleanly.
+
+SUDO=""
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+fi
+mkdir -p "$HOME/.local/bin"
+
+note() { printf '[dev-openshift] %s\n' "$*"; }
+
+# ---- Node.js 22 LTS via fnm ----
+if ! command -v fnm >/dev/null 2>&1; then
+  note "installing fnm into ~/.local/bin"
+  curl -fsSL https://fnm.vercel.app/install \
+    | bash -s -- --install-dir "$HOME/.local/bin" --skip-shell >/dev/null 2>&1 || \
+    note "fnm install failed; skipping Node"
+fi
+if command -v fnm >/dev/null 2>&1; then
+  export PATH="$HOME/.local/bin:$PATH"
+  eval "$(fnm env)" 2>/dev/null || true
+  if ! fnm list 2>/dev/null | grep -q 'v22\.'; then
+    note "installing Node 22 LTS"
+    fnm install 22 >/dev/null 2>&1 || note "fnm install 22 failed"
+  fi
+  fnm alias default 22 >/dev/null 2>&1 || true
+fi
+
+# ---- Python 3 (full stdlib + venv) ----
+if ! python3 -c 'import venv, ensurepip' >/dev/null 2>&1; then
+  note "installing python3 + venv support"
+  if command -v apt-get >/dev/null 2>&1; then
+    $SUDO apt-get install -y python3-full python3-venv python3-pip 2>/dev/null || true
+  elif command -v dnf >/dev/null 2>&1; then
+    $SUDO dnf install -y python3 python3-pip 2>/dev/null || true
+  elif command -v pacman >/dev/null 2>&1; then
+    $SUDO pacman -Sy --noconfirm python python-pip 2>/dev/null || true
+  fi
+fi
+
+# ---- Ansible (isolated; uv tool, falling back to a venv) ----
+if ! command -v ansible >/dev/null 2>&1; then
+  if command -v uv >/dev/null 2>&1; then
+    note "installing ansible via uv tool"
+    uv tool install --quiet ansible || note "uv tool install ansible failed"
+  else
+    note "uv not found; installing ansible into ~/.venvs/ansible"
+    if python3 -m venv "$HOME/.venvs/ansible" 2>/dev/null; then
+      "$HOME/.venvs/ansible/bin/pip" install --quiet --upgrade pip ansible || true
+      ln -sf "$HOME/.venvs/ansible/bin/ansible"          "$HOME/.local/bin/ansible"
+      ln -sf "$HOME/.venvs/ansible/bin/ansible-playbook" "$HOME/.local/bin/ansible-playbook"
+    fi
+  fi
+fi
+
+# ---- Windows .exe shims (WSL only) ----
+# Podman / Helm / oc come from the FIPS-approved Windows install, reached via
+# WSL interop. Git stays WSL-native on purpose (shimming git.exe breaks path
+# translation). Best-effort: link when present, otherwise point at the bootstrap.
+if grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null; then
+  for tool in podman helm oc; do
+    if exe="$(command -v "$tool.exe" 2>/dev/null)"; then
+      ln -sf "$exe" "$HOME/.local/bin/$tool"
+      note "linked $tool -> $exe"
+    else
+      note "$tool.exe not on Windows PATH — install it on Windows (scripts/windows-client.ps1)"
+    fi
+  done
+fi
+
+{{ end -}}

--- a/scripts/windows-client.ps1
+++ b/scripts/windows-client.ps1
@@ -1,0 +1,80 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs the Windows-side OpenShift client toolchain for the WSL dev box.
+
+.DESCRIPTION
+    Run this ONCE from *Windows PowerShell* (not WSL). It installs the tools that
+    the client doc expects on the Windows side and that the WSL dotfiles then shim
+    into WSL (Podman / Helm / oc). chezmoi (running in WSL) deliberately does NOT
+    install Windows software — this script keeps that boundary explicit.
+
+    The repo lives in WSL; from Windows you can run this via:
+        \\wsl$\<distro>\home\<you>\.local\share\chezmoi\scripts\windows-client.ps1
+
+    Idempotent: winget skips already-installed packages; oc is only downloaded if missing.
+
+.NOTES
+    CRC and its FIPS bundle require a Red Hat pull secret (auth) and cannot be fully
+    automated — see the printed instructions at the end.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+function Info($msg)  { Write-Host "[windows-client] $msg" -ForegroundColor Cyan }
+function Warn($msg)  { Write-Host "[windows-client] $msg" -ForegroundColor Yellow }
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Warn "winget not found. Install 'App Installer' from the Microsoft Store, then re-run."
+    return
+}
+
+function Install-WingetPackage($id, $name) {
+    Info "installing $name ($id)..."
+    winget install -e --id $id --accept-source-agreements --accept-package-agreements `
+        --disable-interactivity 2>&1 | Out-Null
+    if ($LASTEXITCODE -eq 0)            { Info "$name installed." }
+    elseif ($LASTEXITCODE -eq -1978335189) { Info "$name already installed." }  # APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE / no upgrade
+    else                                { Warn "${name}: winget exit $LASTEXITCODE (may already be present)." }
+}
+
+# ---- winget packages ----
+Install-WingetPackage 'RedHat.Podman'          'Podman'
+Install-WingetPackage 'RedHat.Podman-Desktop'  'Podman Desktop'
+Install-WingetPackage 'Helm.Helm'              'Helm'
+Install-WingetPackage 'Git.Git'                'Git for Windows'
+
+# ---- oc (OpenShift CLI) from the public mirror ----
+$ocDir = Join-Path $env:LOCALAPPDATA 'Programs\oc'
+if (Get-Command oc.exe -ErrorAction SilentlyContinue) {
+    Info "oc already on PATH; skipping."
+} else {
+    Info "downloading oc (OpenShift CLI)..."
+    New-Item -ItemType Directory -Force -Path $ocDir | Out-Null
+    $zip = Join-Path $env:TEMP 'openshift-client-windows.zip'
+    $url = 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-windows.zip'
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+        Expand-Archive -Path $zip -DestinationPath $ocDir -Force
+        Remove-Item $zip -Force -ErrorAction SilentlyContinue
+        # Add oc dir to the user PATH (idempotent).
+        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        if ($userPath -notlike "*$ocDir*") {
+            [Environment]::SetEnvironmentVariable('Path', "$userPath;$ocDir", 'User')
+            Info "added $ocDir to user PATH (restart shells to pick it up)."
+        }
+        Info "oc installed to $ocDir."
+    } catch {
+        Warn "oc download failed: $($_.Exception.Message)"
+        Warn "Grab it manually from the Red Hat console: https://console.redhat.com/openshift/downloads"
+    }
+}
+
+# ---- CRC + FIPS bundle (manual; auth-gated) ----
+Write-Host ""
+Warn "CRC (OpenShift Local) + the FIPS bundle need a Red Hat pull secret and are not automated:"
+Write-Host "  1. Download CRC:        https://console.redhat.com/openshift/create/local"
+Write-Host "  2. Download the FIPS bundle (Hyper-V) from the same page."
+Write-Host "  3. crc setup --bundle <path-to-fips-bundle.crcbundle>"
+Write-Host ""
+Info "Done. In WSL, run 'chezmoi apply' so podman/helm/oc get symlinked from these Windows binaries."


### PR DESCRIPTION
## Summary

Opt-in `dev_openshift` flag (off by default; seed with `DOTFILES_OPENSHIFT=1` or answer the init prompt) that provisions the client's OpenShift toolchain so a WSL box can stand on its own.

**Inside WSL/Linux** — `run_dev-openshift.sh.tmpl` (every apply, idempotent, each step guarded):
- Node.js 22 LTS via `fnm` (→ `~/.local/bin`; `env.zsh` adds the `fnm env --use-on-cd` hook)
- Python 3 with `venv`/`pip` (`python3-full` on apt)
- Ansible via `uv tool install ansible` (falls back to a `~/.venvs/ansible` venv)
- On WSL, symlinks `podman`/`helm`/`oc` → the Windows `.exe` (FIPS-approved binaries reached via interop). Git stays WSL-native. Missing `.exe` → prints a hint, no hard fail.

**Windows side** — `scripts/windows-client.ps1`, run once from Windows PowerShell (gitignored from `$HOME`): winget installs Podman / Podman Desktop / Helm / Git, downloads `oc` from the public mirror. CRC + FIPS bundle are pull-secret gated → printed as manual steps.

Consistent with the earlier decision: the WSL apply never installs Windows software — it only shims what's already there; Windows installs live in the explicit, user-run PS1.

## Test plan

- [x] `dig "dev_openshift" false .` gate: no-op when flag absent (verified render); `ENABLED` when true.
- [x] `run_dev-openshift.sh.tmpl`: no-op on darwin; `bash -n` + shellcheck clean for the Linux body.
- [x] `scripts/windows-client.ps1`: parses clean under `pwsh` (caught + fixed a `$name:` scope-qualifier bug).
- [ ] WSL box (flag on): `DOTFILES_OPENSHIFT=1 chezmoi init && chezmoi apply` → `node -v`=v22, `python3 -m venv` works, `ansible --version`, `readlink -f ~/.local/bin/{podman,helm,oc}` → Windows `.exe`, `command -v git`=/usr/bin/git.
- [ ] Windows PS1 run in PowerShell installs the tools; FIPS bundle printed manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)