### PR TITLE
fix(windows-terminal): set font size to 11

### DIFF
--- a/run_windows-terminal.sh.tmpl
+++ b/run_windows-terminal.sh.tmpl
@@ -53,7 +53,7 @@ SCHEME = {
 # `scoop install JetBrainsMono-NF-Mono` (the plain `JetBrains-Mono` package has no
 # glyphs). The "Mono" Nerd Font variant keeps icons single-cell-width for terminals.
 FONT_FACE = "JetBrainsMono Nerd Font Mono"
-FONT_SIZE = 14
+FONT_SIZE = 11
 
 def strip_jsonc(text):
     """Remove // and /* */ comments and trailing commas, respecting strings."""


### PR DESCRIPTION
## Summary

- Windows Terminal profile font size 14 -> 11.

## Test plan

- [ ] `chezmoi apply`, restart Windows Terminal -> 11pt JetBrains Mono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)